### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_ambassador.py
+++ b/reactive/kubeflow_ambassador.py
@@ -6,6 +6,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.kubeflow-ambassador.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('layer.docker-resource.ambassador-image.changed')
 def update_image():
     clear_flag('charm.kubeflow-ambassador.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.