### PR TITLE
Add ambassador relation to Ambassador charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,3 +18,6 @@ resources:
     description: 'Image for ambassador'
     auto-fetch: true
     upstream-source: 'quay.io/datawire/ambassador:0.30.1'
+provides:
+  ambassador:
+    interface: ambassador


### PR DESCRIPTION
Allows other charms to get notified when Ambassador exists, so that they can create annotations on themselves.